### PR TITLE
Added support for passing options to the request library

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,9 @@ module.exports = function(options) {
    * options.tag
    * options.name
    */
-  var option, stream, token, _i, _len, _ref;
+  var baseRequest, option, stream, token, _i, _len, _ref;
+  baseRequest = request.defaults(options.requestOptions);
+  baseRequest.uri = "https://api.github.com/repos/" + options.repo + "/releases" + token;
   _ref = ['repo', 'tag', 'name'];
   for (_i = 0, _len = _ref.length; _i < _len; _i++) {
     option = _ref[_i];
@@ -29,7 +31,7 @@ module.exports = function(options) {
     }
   }
   token = options.token ? "?access_token=" + options.token : "";
-  return stream = _(request("https://api.github.com/repos/" + options.repo + "/releases" + token).pipe(JSONStream.parse('*'))).map(function(res) {
+  return stream = _(baseRequest("https://api.github.com/repos/" + options.repo + "/releases" + token).pipe(JSONStream.parse('*'))).map(function(res) {
     if (typeof res === 'string') {
       return stream.emit('error', new Error(("" + options.repo + " " + options.tag + " " + options.name + " ") + res));
     } else {
@@ -45,6 +47,6 @@ module.exports = function(options) {
     var uri;
     uri = "https://github.com/" + options.repo + "/releases/download/" + options.tag + "/" + asset.name;
     stream.emit('size', asset.size);
-    return _(request(uri));
+    return _(baseRequest(uri));
   });
 };

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -15,11 +15,13 @@ module.exports = (options)->
      * options.name
     ###
 
+    baseRequest = request.defaults(options.requestOptions)
+
     for option in ['repo', 'tag', 'name']
         if !options || !options[option]
             throw new Error("Miss option #{option}")
     token = if options.token then "?access_token=" + options.token else ""
-    stream = _(request("https://api.github.com/repos/#{options.repo}/releases#{token}")
+    stream = _(baseRequest("https://api.github.com/repos/#{options.repo}/releases#{token}")
     .pipe(JSONStream.parse('*')))
     .map (res)->
         if typeof res is 'string'
@@ -34,4 +36,4 @@ module.exports = (options)->
     .flatMap (asset)->
         uri = "https://github.com/#{options.repo}/releases/download/#{options.tag}/#{asset.name}"
         stream.emit 'size', asset.size
-        return _(request(uri))
+        return _(baseRequest(uri))


### PR DESCRIPTION
I've added the ability to configure the request object through options, useful if you need to use this behind a proxy.
