### PR TITLE
Add authorization to download request.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,13 +6,6 @@ _ = require('highland');
 
 JSONStream = require('JSONStream');
 
-request = request.defaults({
-  headers: {
-    accept: 'application/vnd.github.manifold-preview',
-    'user-agent': 'grs-releases/' + require('../package.json').version
-  }
-});
-
 module.exports = function(options) {
 
   /**
@@ -20,9 +13,18 @@ module.exports = function(options) {
    * options.tag
    * options.name
    */
-  var baseRequest, option, stream, token, _i, _len, _ref;
+  var baseRequest, headers, option, stream, _i, _len, _ref;
+  headers = {
+    'Accept': 'application/vnd.github.v3',
+    'User-Agent': 'grs-releases/' + require('../package.json').version
+  };
+  if (options.token) {
+    headers['Authorization'] = 'token ' + options.token;
+  }
+  request = request.defaults({
+    headers: headers
+  });
   baseRequest = request.defaults(options.requestOptions);
-  baseRequest.uri = "https://api.github.com/repos/" + options.repo + "/releases" + token;
   _ref = ['repo', 'tag', 'name'];
   for (_i = 0, _len = _ref.length; _i < _len; _i++) {
     option = _ref[_i];
@@ -30,8 +32,7 @@ module.exports = function(options) {
       throw new Error("Miss option " + option);
     }
   }
-  token = options.token ? "?access_token=" + options.token : "";
-  return stream = _(baseRequest("https://api.github.com/repos/" + options.repo + "/releases" + token).pipe(JSONStream.parse('*'))).map(function(res) {
+  return stream = _(baseRequest("https://api.github.com/repos/" + options.repo + "/releases").pipe(JSONStream.parse('*'))).map(function(res) {
     if (typeof res === 'string') {
       return stream.emit('error', new Error(("" + options.repo + " " + options.tag + " " + options.name + " ") + res));
     } else {
@@ -44,9 +45,11 @@ module.exports = function(options) {
   }).flatten().find(function(asset) {
     return asset.name === options.name;
   }).flatMap(function(asset) {
-    var uri;
-    uri = "https://github.com/" + options.repo + "/releases/download/" + options.tag + "/" + asset.name;
     stream.emit('size', asset.size);
-    return _(baseRequest(uri));
+    return _(baseRequest(asset.url, {
+      headers: {
+        'Accept': 'application/octet-stream'
+      }
+    }));
   });
 };


### PR DESCRIPTION
Makes the following changes:
- Updates the `Accept` header that indicates the GitHub API version to the latest.
- Adds the optional token as a default `Authorization` header rather than `access_token` query parameter.
- Applies the optional token to the actual request to download the asset.
- Uses the `url` asset property rather than (build the equivalent of) the `browser_download_url` property, the latter which seems not to work for private repos.
